### PR TITLE
Add Docker support with web interface enabled

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+# Use Eclipse Temurin as base image with Java 21
+FROM eclipse-temurin:21-jdk-jammy
+
+# Install development tools
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install git curl unzip zip \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Install Maven (instead of using wrapper to ensure latest version)
+RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz | tar xzf - -C /opt \
+    && ln -s /opt/apache-maven-3.9.6/bin/mvn /usr/local/bin/mvn
+
+# Set environment variables
+ENV JAVA_HOME=/opt/java/openjdk \
+    MAVEN_HOME=/opt/apache-maven-3.9.6 \
+    MAVEN_CONFIG=/root/.m2
+
+# Create source directory
+WORKDIR /workspace/app
+
+# Add a non-root user 'vscode' for development
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && mkdir -p /home/$USERNAME/.m2 \
+    && chown -R $USERNAME:$USERNAME /home/$USERNAME
+
+# Switch to non-root user
+USER $USERNAME 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+    "name": "ChatDM Development",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vscjava.vscode-java-pack",
+                "vmware.vscode-spring-boot",
+                "vscjava.vscode-spring-boot-dashboard",
+                "vscjava.vscode-spring-initializr",
+                "redhat.vscode-yaml",
+                "eamodio.gitlens"
+            ],
+            "settings": {
+                "java.configuration.updateBuildConfiguration": "automatic",
+                "java.server.launchMode": "Standard"
+            }
+        }
+    },
+    "forwardPorts": [8080],
+    "postCreateCommand": "mvn dependency:go-offline",
+    "remoteUser": "vscode",
+    "mounts": [
+        "source=${localEnv:HOME}/.m2,target=/home/vscode/.m2,type=bind,consistency=cached"
+    ]
+} 

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ docker-compose.override.yml
 
 ### Dev Container ###
 .devcontainer/devcontainer.env
+
+### macOS ###
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Docker ###
+.docker/
+docker-compose.override.yml

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build/
 ### Docker ###
 .docker/
 docker-compose.override.yml
+
+### Dev Container ###
+.devcontainer/devcontainer.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Use Eclipse Temurin as base image with Java 21
+FROM eclipse-temurin:21-jdk-jammy
+
+# Set working directory
+WORKDIR /app
+
+# Copy the Maven wrapper files
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml .
+
+# Make the Maven wrapper executable
+RUN chmod +x mvnw
+
+# Copy the source code
+COPY src src
+
+# Build the application
+RUN ./mvnw package -DskipTests
+
+# Expose the port the app runs on
+EXPOSE 8080
+
+# Run the application with web mode enabled
+CMD ["java", "-jar", "-Dspring.main.web-application-type=SERVLET", "target/chatdm-0.0.1-SNAPSHOT.jar"] 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,45 @@ Currently, there are:
 
 (I have not written Java since 2005, so I have no idea what I'm doing with this fancy, new Spring Boot style.)
 
+# Docker Support
+
+You can run ChatDM in a Docker container, which provides an isolated environment with all necessary dependencies. The included Dockerfile uses Eclipse Temurin Java 21 as the base image and sets up the application with its web interface enabled.
+
+## Building and Running with Docker
+
+1. Build the Docker image:
+   ```bash
+   docker build -t chatdm .
+   ```
+
+2. Run the container:
+   ```bash
+   docker run -d -p 8080:8080 chatdm
+   ```
+
+This will start the application and expose it on port 8080.
+
+## Testing the Oracle Endpoints
+
+Once the container is running, you can test the Oracle endpoints using curl or your web browser:
+
+1. List all available oracles:
+   ```bash
+   curl http://localhost:8080/chatdm/api/oracle
+   ```
+
+2. Get information about all oracles:
+   ```bash
+   curl http://localhost:8080/chatdm/api/oracle/info
+   ```
+
+3. Get a random entry from a specific oracle (e.g., NPC_Motivations):
+   ```bash
+   curl http://localhost:8080/chatdm/api/oracle/NPC_Motivations/random
+   ```
+
+The responses will be in JSON format, making it easy to integrate with other tools or scripts.
+
 # DM Journal
 
 This is one of the most exciting parts! It's fun to see when the AI (MCP Client, here, Claude desktop) chooses to write something down in its journal. Even better, it will remember what has been happening in the adventure by reloading it. Also, you get a nice accounting of it.


### PR DESCRIPTION
Add Docker support with web interface enabled

This PR adds Docker support to the project with the following changes:
- Add Dockerfile for building and running the application
- Update README with Docker build and usage instructions
- Add Docker-related entries to .gitignore
- Enable web interface in Docker container for Oracle endpoints

The Docker configuration uses Eclipse Temurin Java 21 as the base image and enables the web interface to allow access to the Oracle endpoints via HTTP.

Testing done:
- Built and ran the container successfully
- Verified all Oracle endpoints are accessible and working
- Tested example queries for all endpoints